### PR TITLE
Added JSON output

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -16,24 +16,24 @@ Video Frame Matcher is a command-line tool that detects occurrences of a referen
 - Configurable frame-step scanning
 
 ## Installation
-#### Build
+Build:
 ```sh
 cmake -S . -B build
 cmake --build build
 ```
 
-#### Install vfm to ~/.local/bin (make sure this is on your PATH)
+Install vfm to ~/.local/bin (make sure this is on your PATH):
 ```sh
 cmake --install build --prefix ~/.local
 ```
 
 ## How to Use
-### Basic Detection
+Basic Detection:
 ```sh
 vfm --video clip.mp4 --image ref.png
 ```
 
-### Tuned Search
+Tuned Search:
 ```sh
 vfm \
   --video clip.mp4 \
@@ -58,7 +58,7 @@ cd build
 ctest --output-on-failure
 ```
 
-(Optional) Run the test binary directly
+(Optional) Run the test binary directly:
 ```sh
 cd build/tests
 ./test_vfm

--- a/readme.md
+++ b/readme.md
@@ -45,8 +45,61 @@ vfm \
 ```
 
 ## Output Format
+Stdout:
 ```sh
-TBA
+video-frame-matcher$ vfm --video clip.mp4 --image ref.jpg --output-json ./output.json
+Found 16 match(es)
+Best match at frame # 148 (2.96s) with confidence of 99.9494%.
+JSON output written to: ./output.json
+```
+
+Json Output:
+```json
+{
+    "image": {
+        "channels": 3,
+        "height": 1366,
+        "path": "ref2.jpg",
+        "width": 720
+    },
+    "matches": [
+        {
+            "bbox": {
+                "h": 1366,
+                "w": 720,
+                "x": 0,
+                "y": 0
+            },
+            "frame_index": 139,
+            "has_bbox": true,
+            "score": 0.8710225820541382,
+            "time_seconds": 2.78
+        },
+        {
+            "bbox": {
+                "h": 1366,
+                "w": 720,
+                "x": 0,
+                "y": 0
+            },
+            "frame_index": 140,
+            "has_bbox": true,
+            "score": 0.8710888028144836,
+            "time_seconds": 2.8
+        },
+...
+
+    ],
+    "status": "SUCCESS",
+    "video": {
+        "duration_sec": 20.04,
+        "fps": 50.0,
+        "frame_count": 1002,
+        "height": 1366,
+        "path": "test.mp4",
+        "width": 720
+    }
+}
 ```
 
 ## Testing

--- a/readme.md
+++ b/readme.md
@@ -14,6 +14,7 @@ Video Frame Matcher is a command-line tool that detects occurrences of a referen
 - Deterministic, scriptable CLI output
 - Configurable similarity threshold
 - Configurable frame-step scanning
+- Optional JSON export 
 
 ## Installation
 Build:

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_subdirectory(cli)
 add_subdirectory(core)
 add_subdirectory(io)
+add_subdirectory(json)
 
 add_executable(vfm
     main.cpp
@@ -10,6 +11,7 @@ target_link_libraries(vfm PUBLIC
     vfm_cli
     vfm_core
     vfm_io
+    vfm_json
 )
 
 if(OpenCV_FOUND)

--- a/src/core/vfm_imagesearch.cpp
+++ b/src/core/vfm_imagesearch.cpp
@@ -1,10 +1,6 @@
 #include <vfm_imagesearch.h>
 #include <opencv2/opencv.hpp>
 
-namespace {
-	const std::string OUTPUT_DIR = "output/";
-}  // namespace
-
 // Search Functions
 void ImageSearch::isImageWithinFrame(const cv::Mat& image, const cv::Mat& frame, int frame_index, double fps, double threshold, std::vector<Match>& matches)
 {

--- a/src/io/vfm_io.cpp
+++ b/src/io/vfm_io.cpp
@@ -12,7 +12,7 @@ void printResults(const MatchResults &results)
     }
 
     // Find the best match
-    auto best_match = std::max_element(results.matches.begin(), results.matches.end(),
+    const auto best_match = std::max_element(results.matches.begin(), results.matches.end(),
     [](const Match& a, const Match& b) { return a.score < b.score; });
 
     if (best_match != results.matches.end()) {

--- a/src/json/CMakeLists.txt
+++ b/src/json/CMakeLists.txt
@@ -1,0 +1,25 @@
+add_library(vfm_json
+    vfm_json.cpp
+)
+
+target_include_directories(vfm_json PUBLIC ./)
+
+# Link to vfm_core for vfm_types.h
+target_link_libraries(vfm_json PUBLIC vfm_core)
+
+# Fetch nlohmann's json (https://github.com/nlohmann/json)
+find_package(nlohmann_json QUIET)
+if(nlohmann_json_FOUND)
+	target_link_libraries(vfm_json PUBLIC ${nlohmann_json_LIBS})
+	target_include_directories(vfm_json PUBLIC ${nlohmann_json_INCLUDE_DIRS})
+else()
+    include(FetchContent)
+
+    FetchContent_Declare(
+        nlohmann_json
+        URL https://github.com/nlohmann/json/archive/refs/tags/v3.12.0.zip
+    )
+    FetchContent_MakeAvailable(nlohmann_json)
+
+    target_link_libraries(vfm_json PUBLIC nlohmann_json::nlohmann_json)
+endif()

--- a/src/json/vfm_json.cpp
+++ b/src/json/vfm_json.cpp
@@ -1,0 +1,92 @@
+#include <vfm_json.h>
+#include <fstream>
+
+namespace vfm {
+
+static const char* matchStatusToString(MatchStatus status) {
+    switch (status) {
+        case MatchStatus::e_SUCCESS:
+            return "SUCCESS";
+        case MatchStatus::e_NO_MATCH_FOUND:
+            return "NO_MATCH_FOUND";
+        case MatchStatus::e_BAD_FILE:
+            return "BAD_FILE";
+        default:
+            return "UNKNOWN";
+    }
+}
+
+nlohmann::json matchResultsToJson(const MatchResults& results) {
+    nlohmann::json j;
+
+    // Add status
+    j["status"] = matchStatusToString(results.status);
+
+    // Add video metadata
+    j["video"] = {
+        {"path", results.video.path},
+        {"fps", results.video.fps},
+        {"frame_count", results.video.frame_count},
+        {"duration_sec", results.video.duration_sec},
+        {"width", results.video.width},
+        {"height", results.video.height}
+    };
+
+    // Add image metadata
+    j["image"] = {
+        {"path", results.image.path},
+        {"width", results.image.width},
+        {"height", results.image.height},
+        {"channels", results.image.channels}
+    };
+
+    // Add matches
+    nlohmann::json matches = nlohmann::json::array();
+    for (const auto& match : results.matches) {
+        nlohmann::json match_obj = {
+            {"time_seconds", match.time_seconds},
+            {"frame_index", match.frame_index},
+            {"score", match.score},
+            {"has_bbox", match.has_bbox}
+        };
+
+        if (match.has_bbox) {
+            match_obj["bbox"] = {
+                {"x", match.x},
+                {"y", match.y},
+                {"w", match.w},
+                {"h", match.h}
+            };
+        }
+
+        matches.push_back(match_obj);
+    }
+    j["matches"] = matches;
+
+    return j;
+}
+
+std::string matchResultsToJsonString(const MatchResults& results, int indent) {
+    return matchResultsToJson(results).dump(indent);
+}
+
+bool writeMatchResultsToFile(const MatchResults& results,
+                              const std::string& filename,
+                              int indent) {
+    try {
+        std::ofstream file(filename);
+        if (!file.is_open()) {
+            return false;
+        }
+
+        nlohmann::json j = matchResultsToJson(results);
+        file << j.dump(indent);
+        file.close();
+
+        return true;
+    } catch (...) {
+        return false;
+    }
+}
+
+}

--- a/src/json/vfm_json.h
+++ b/src/json/vfm_json.h
@@ -1,0 +1,22 @@
+#ifndef INCLUDED_VFM_JSON
+#define INCLUDED_VFM_JSON
+
+#include <nlohmann/json.hpp>
+
+#include <string>
+
+#include <vfm_types.h>
+
+namespace vfm {
+
+nlohmann::json matchResultsToJson(const MatchResults& results);
+
+std::string matchResultsToJsonString(const MatchResults& results, int indent = -1);
+
+bool writeMatchResultsToFile(const MatchResults& results,
+                              const std::string& filename,
+                              int indent = 4);
+
+}
+
+#endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,6 +6,7 @@
 #include <vfm_args.h>
 #include <vfm_imagesearch.h>
 #include <vfm_io.h>
+#include <vfm_json.h>
 #include <vfm_types.h>
 
 int main(int argc, char** argv) {
@@ -38,6 +39,14 @@ int main(int argc, char** argv) {
         default:
             std::cerr << "Error: internal error" << std::endl;
             return 4;
+    }
+
+    if (!args.output_json.empty()) {
+        if (!vfm::writeMatchResultsToFile(results, args.output_json)) {
+            std::cerr << "Error: failed to write JSON output to " << args.output_json << std::endl;
+            return 3;
+        }
+        std::cout << "JSON output written to: " << args.output_json << std::endl;
     }
 
 	return 0;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ target_link_libraries(test_vfm
 		GTest::gtest_main
 		vfm_cli
 		vfm_core
+		vfm_json
 )
 target_include_directories(test_vfm PUBLIC ./)
 
@@ -22,6 +23,7 @@ target_sources(test_vfm
 	PRIVATE
 		vfm_args.t.cpp
 		vfm_imagesearch.t.cpp
+		vfm_json.t.cpp
 		vfm_testimages.cpp
 )
 

--- a/tests/vfm_json.t.cpp
+++ b/tests/vfm_json.t.cpp
@@ -1,0 +1,317 @@
+#include <gtest/gtest.h>
+#include <vfm_json.h>
+#include <nlohmann/json.hpp>
+#include <fstream>
+#include <filesystem>
+
+// Test fixture to clean up test files
+class VfmJsonTest : public ::testing::Test {
+protected:
+    void TearDown() override {
+        // Clean up any test files created
+        for (const auto& file : test_files_) {
+            std::filesystem::remove(file);
+        }
+    }
+
+    void trackFile(const std::string& filename) {
+        test_files_.push_back(filename);
+    }
+
+private:
+    std::vector<std::string> test_files_;
+};
+
+TEST_F(VfmJsonTest, matchResultsToJsonCreatesValidJsonGivenSuccessfulMatchWithBbox) {
+    // Given
+    MatchResults results;
+    results.status = MatchStatus::e_SUCCESS;
+    results.video = {"video.mp4", 30.0, 900, 30.0, 1920, 1080};
+    results.image = {"image.jpg", 640, 480, 3};
+
+    Match match;
+    match.time_seconds = 5.5;
+    match.frame_index = 165;
+    match.score = 0.95;
+    match.has_bbox = true;
+    match.x = 100;
+    match.y = 200;
+    match.w = 300;
+    match.h = 400;
+    results.matches.push_back(match);
+
+    // When
+    nlohmann::json j = vfm::matchResultsToJson(results);
+
+    // Then
+    EXPECT_EQ(j["status"], "SUCCESS");
+    EXPECT_EQ(j["video"]["path"], "video.mp4");
+    EXPECT_DOUBLE_EQ(j["video"]["fps"], 30.0);
+    EXPECT_EQ(j["video"]["frame_count"], 900);
+    EXPECT_DOUBLE_EQ(j["video"]["duration_sec"], 30.0);
+    EXPECT_EQ(j["video"]["width"], 1920);
+    EXPECT_EQ(j["video"]["height"], 1080);
+    EXPECT_EQ(j["image"]["path"], "image.jpg");
+    EXPECT_EQ(j["image"]["width"], 640);
+    EXPECT_EQ(j["image"]["height"], 480);
+    EXPECT_EQ(j["image"]["channels"], 3);
+    ASSERT_EQ(j["matches"].size(), 1);
+    EXPECT_DOUBLE_EQ(j["matches"][0]["time_seconds"], 5.5);
+    EXPECT_EQ(j["matches"][0]["frame_index"], 165);
+    EXPECT_DOUBLE_EQ(j["matches"][0]["score"], 0.95);
+    EXPECT_TRUE(j["matches"][0]["has_bbox"]);
+    EXPECT_EQ(j["matches"][0]["bbox"]["x"], 100);
+    EXPECT_EQ(j["matches"][0]["bbox"]["y"], 200);
+    EXPECT_EQ(j["matches"][0]["bbox"]["w"], 300);
+    EXPECT_EQ(j["matches"][0]["bbox"]["h"], 400);
+}
+
+TEST_F(VfmJsonTest, matchResultsToJsonExcludesBboxGivenMatchWithoutBbox) {
+    // Given
+    MatchResults results;
+    results.status = MatchStatus::e_SUCCESS;
+    results.video = {"video.mp4", 30.0, 900, 30.0, 1920, 1080};
+    results.image = {"image.jpg", 640, 480, 3};
+
+    Match match;
+    match.time_seconds = 12.3;
+    match.frame_index = 369;
+    match.score = 0.87;
+    match.has_bbox = false;
+    results.matches.push_back(match);
+
+    // When
+    nlohmann::json j = vfm::matchResultsToJson(results);
+
+    // Then
+    ASSERT_EQ(j["matches"].size(), 1);
+    EXPECT_FALSE(j["matches"][0]["has_bbox"]);
+    EXPECT_FALSE(j["matches"][0].contains("bbox"));
+}
+
+TEST_F(VfmJsonTest, matchResultsToJsonHandlesNoMatchFoundStatus) {
+    // Given
+    MatchResults results;
+    results.status = MatchStatus::e_NO_MATCH_FOUND;
+    results.video = {"video.mp4", 30.0, 900, 30.0, 1920, 1080};
+    results.image = {"image.jpg", 640, 480, 3};
+
+    // When
+    nlohmann::json j = vfm::matchResultsToJson(results);
+
+    // Then
+    EXPECT_EQ(j["status"], "NO_MATCH_FOUND");
+    EXPECT_EQ(j["matches"].size(), 0);
+}
+
+TEST_F(VfmJsonTest, matchResultsToJsonHandlesBadFileStatus) {
+    // Given
+    MatchResults results;
+    results.status = MatchStatus::e_BAD_FILE;
+    results.video = {"video.mp4", 0.0, 0, 0.0, 0, 0};
+    results.image = {"image.jpg", 0, 0, 0};
+
+    // When
+    nlohmann::json j = vfm::matchResultsToJson(results);
+
+    // Then
+    EXPECT_EQ(j["status"], "BAD_FILE");
+}
+
+TEST_F(VfmJsonTest, matchResultsToJsonHandlesMultipleMatches) {
+    // Given
+    MatchResults results;
+    results.status = MatchStatus::e_SUCCESS;
+    results.video = {"video.mp4", 30.0, 900, 30.0, 1920, 1080};
+    results.image = {"image.jpg", 640, 480, 3};
+
+    Match match1;
+    match1.time_seconds = 5.5;
+    match1.frame_index = 165;
+    match1.score = 0.95;
+    match1.has_bbox = true;
+    match1.x = 100;
+    match1.y = 200;
+    match1.w = 300;
+    match1.h = 400;
+
+    Match match2;
+    match2.time_seconds = 12.3;
+    match2.frame_index = 369;
+    match2.score = 0.87;
+    match2.has_bbox = false;
+
+    Match match3;
+    match3.time_seconds = 20.1;
+    match3.frame_index = 603;
+    match3.score = 0.92;
+    match3.has_bbox = true;
+    match3.x = 50;
+    match3.y = 75;
+    match3.w = 200;
+    match3.h = 150;
+
+    results.matches.push_back(match1);
+    results.matches.push_back(match2);
+    results.matches.push_back(match3);
+
+    // When
+    nlohmann::json j = vfm::matchResultsToJson(results);
+
+    // Then
+    ASSERT_EQ(j["matches"].size(), 3);
+    EXPECT_DOUBLE_EQ(j["matches"][0]["time_seconds"], 5.5);
+    EXPECT_DOUBLE_EQ(j["matches"][1]["time_seconds"], 12.3);
+    EXPECT_DOUBLE_EQ(j["matches"][2]["time_seconds"], 20.1);
+    EXPECT_TRUE(j["matches"][0]["has_bbox"]);
+    EXPECT_FALSE(j["matches"][1]["has_bbox"]);
+    EXPECT_TRUE(j["matches"][2]["has_bbox"]);
+}
+
+TEST_F(VfmJsonTest, matchResultsToJsonStringCreatesFormattedStringGivenIndent) {
+    // Given
+    MatchResults results;
+    results.status = MatchStatus::e_SUCCESS;
+    results.video = {"video.mp4", 30.0, 900, 30.0, 1920, 1080};
+    results.image = {"image.jpg", 640, 480, 3};
+
+    // When
+    std::string json_str = vfm::matchResultsToJsonString(results, 4);
+
+    // Then
+    EXPECT_TRUE(json_str.find("    ") != std::string::npos); // Contains indentation
+    EXPECT_TRUE(json_str.find("\"status\": \"SUCCESS\"") != std::string::npos);
+    EXPECT_TRUE(json_str.find("\"video\"") != std::string::npos);
+    EXPECT_TRUE(json_str.find("\"image\"") != std::string::npos);
+}
+
+TEST_F(VfmJsonTest, matchResultsToJsonStringCreatesCompactStringGivenNoIndent) {
+    // Given
+    MatchResults results;
+    results.status = MatchStatus::e_SUCCESS;
+    results.video = {"video.mp4", 30.0, 900, 30.0, 1920, 1080};
+    results.image = {"image.jpg", 640, 480, 3};
+
+    // When
+    std::string json_str = vfm::matchResultsToJsonString(results, -1);
+
+    // Then
+    EXPECT_TRUE(json_str.find("\n") == std::string::npos); // No newlines
+    EXPECT_TRUE(json_str.find("\"status\":\"SUCCESS\"") != std::string::npos);
+}
+
+TEST_F(VfmJsonTest, writeMatchResultsToFileCreatesFileGivenValidPath) {
+    // Given
+    MatchResults results;
+    results.status = MatchStatus::e_SUCCESS;
+    results.video = {"video.mp4", 30.0, 900, 30.0, 1920, 1080};
+    results.image = {"image.jpg", 640, 480, 3};
+
+    Match match;
+    match.time_seconds = 5.5;
+    match.frame_index = 165;
+    match.score = 0.95;
+    match.has_bbox = true;
+    match.x = 100;
+    match.y = 200;
+    match.w = 300;
+    match.h = 400;
+    results.matches.push_back(match);
+
+    std::string filename = "test_output_valid.json";
+    trackFile(filename);
+
+    // When
+    bool success = vfm::writeMatchResultsToFile(results, filename, 4);
+
+    // Then
+    EXPECT_TRUE(success);
+    EXPECT_TRUE(std::filesystem::exists(filename));
+
+    // Verify file contents
+    std::ifstream file(filename);
+    ASSERT_TRUE(file.is_open());
+    nlohmann::json j;
+    file >> j;
+    file.close();
+
+    EXPECT_EQ(j["status"], "SUCCESS");
+    EXPECT_EQ(j["video"]["path"], "video.mp4");
+    EXPECT_EQ(j["matches"].size(), 1);
+    EXPECT_DOUBLE_EQ(j["matches"][0]["score"], 0.95);
+}
+
+TEST_F(VfmJsonTest, writeMatchResultsToFileReturnsFalseGivenInvalidPath) {
+    // Given
+    MatchResults results;
+    results.status = MatchStatus::e_SUCCESS;
+    results.video = {"video.mp4", 30.0, 900, 30.0, 1920, 1080};
+    results.image = {"image.jpg", 640, 480, 3};
+
+    // When
+    bool success = vfm::writeMatchResultsToFile(results, "/invalid/path/that/does/not/exist/output.json", 4);
+
+    // Then
+    EXPECT_FALSE(success);
+}
+
+TEST_F(VfmJsonTest, writeMatchResultsToFileWritesCompactJsonGivenNegativeIndent) {
+    // Given
+    MatchResults results;
+    results.status = MatchStatus::e_NO_MATCH_FOUND;
+    results.video = {"video.mp4", 30.0, 900, 30.0, 1920, 1080};
+    results.image = {"image.jpg", 640, 480, 3};
+
+    std::string filename = "test_output_compact.json";
+    trackFile(filename);
+
+    // When
+    bool success = vfm::writeMatchResultsToFile(results, filename, -1);
+
+    // Then
+    EXPECT_TRUE(success);
+
+    std::ifstream file(filename);
+    ASSERT_TRUE(file.is_open());
+    std::string content((std::istreambuf_iterator<char>(file)),
+                        std::istreambuf_iterator<char>());
+    file.close();
+
+    // Compact JSON should not have newlines
+    EXPECT_TRUE(content.find("\n") == std::string::npos);
+}
+
+TEST_F(VfmJsonTest, writeMatchResultsToFileOverwritesExistingFile) {
+    // Given
+    std::string filename = "test_overwrite.json";
+    trackFile(filename);
+
+    // Create initial file
+    MatchResults results1;
+    results1.status = MatchStatus::e_NO_MATCH_FOUND;
+    results1.video = {"old_video.mp4", 25.0, 750, 30.0, 1280, 720};
+    results1.image = {"old_image.jpg", 320, 240, 3};
+
+    vfm::writeMatchResultsToFile(results1, filename, 4);
+
+    // Create new results
+    MatchResults results2;
+    results2.status = MatchStatus::e_SUCCESS;
+    results2.video = {"new_video.mp4", 60.0, 1800, 30.0, 3840, 2160};
+    results2.image = {"new_image.jpg", 1920, 1080, 3};
+
+    // When
+    bool success = vfm::writeMatchResultsToFile(results2, filename, 4);
+
+    // Then
+    EXPECT_TRUE(success);
+
+    std::ifstream file(filename);
+    nlohmann::json j;
+    file >> j;
+    file.close();
+
+    EXPECT_EQ(j["status"], "SUCCESS");
+    EXPECT_EQ(j["video"]["path"], "new_video.mp4");
+    EXPECT_EQ(j["video"]["fps"], 60.0);
+}


### PR DESCRIPTION
Added JSON output to show data on the search that was conducted. It'll provide the Image metadata, video metadata, and each substantial match found in the search. Details on these types can be viewed in the readme's [Output Format](https://github.com/dariustb/video-frame-matcher#output-format) section. 

The trigger for json output is set in the command line args and managed within the main() function, exporting after an _ok_ status run of the app.