### PR TITLE
Object updates

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(vfm_core
     vfm_imagesearch.cpp
+    vfm_types.cpp
 )
 
 target_include_directories(vfm_core PUBLIC ./)

--- a/src/core/vfm_imagesearch.cpp
+++ b/src/core/vfm_imagesearch.cpp
@@ -21,15 +21,15 @@ void ImageSearch::isImageWithinFrame(const cv::Mat& image, const cv::Mat& frame,
     const int min_distance = std::max(image.cols, image.rows) / 2;
 
     for (const auto& loc : locations) {
-        double confidence = result.at<float>(loc);
+        const double confidence = result.at<float>(loc);
 
         // Check if this location is too close to an existing match
         bool is_duplicate = false;
-        for (const auto& existing : matches) {
+        for (const Match& existing : matches) {
             if (existing.frame_index == frame_index) {
-                int dx = loc.x - existing.x;
-                int dy = loc.y - existing.y;
-                int distance = std::sqrt(dx*dx + dy*dy);
+                const int dx = loc.x - existing.x;
+                const int dy = loc.y - existing.y;
+                const int distance = std::sqrt(dx*dx + dy*dy);
                 if (distance < min_distance) {
                     is_duplicate = true;
                     break;
@@ -38,16 +38,16 @@ void ImageSearch::isImageWithinFrame(const cv::Mat& image, const cv::Mat& frame,
         }
 
         if (!is_duplicate) {
-            Match match;
-            match.frame_index = frame_index;
-            match.time_seconds = (fps > 0) ? (frame_index / fps) : 0.0;
-            match.score = confidence;
-            match.has_bbox = true;
-            match.x = loc.x;
-            match.y = loc.y;
-            match.w = image.cols;
-            match.h = image.rows;
-
+            const Match match(
+                fps ? (frame_index / fps) : 0.0,
+                frame_index,
+                confidence,
+                true,
+                loc.x,
+                loc.y,
+                image.cols,
+                image.rows
+            );
             matches.push_back(match);
         }
     }
@@ -59,11 +59,10 @@ MatchStatus ImageSearch::isImageWithinVideo(const cv::Mat& target_image, cv::Vid
 		return MatchStatus::e_BAD_FILE;
 	}
 
-	cv::Mat   frame;
+	matches.clear();
+	cv::Mat frame;
 	const int total_frames = static_cast<int>(source_video.get(cv::CAP_PROP_FRAME_COUNT));
 	const double fps = source_video.get(cv::CAP_PROP_FPS);
-
-	matches.clear();
 
 	for (int frame_index = 1; frame_index <= total_frames; ++frame_index) {
 		// Read next frame from video
@@ -83,72 +82,50 @@ MatchStatus ImageSearch::isImageWithinVideo(const cv::Mat& target_image, cv::Vid
 
 MatchResults ImageSearch::searchVideoForImage(const std::string& image_path, const std::string& video_path, double threshold)
 {
-    MatchResults results;
-
-    cv::VideoCapture video(video_path);
-    cv::Mat          image = cv::imread(image_path);
+    const cv::Mat image = cv::imread(image_path);
 
     if (image.empty()) {
-        results.status = MatchStatus::e_BAD_FILE;
-        return results;
+        const ImageMetadata badImageMeta(image_path);
+        const VideoMetadata badVideoMeta(image_path);
+
+        return MatchResults(MatchStatus::e_BAD_FILE, badImageMeta, badVideoMeta, std::vector<Match>{});
     }
 
     // Populate metadata
-    results.image = getImageMetadata(image_path);
-    results.video = getVideoMetadata(video_path);
+    const ImageMetadata imageMeta = getImageMetadata(image_path);
+    const VideoMetadata videoMeta = getVideoMetadata(video_path);
 
     // Perform the search
-    results.status = isImageWithinVideo(image, video, threshold, results.matches);
+    cv::VideoCapture video(video_path);
+    std::vector<Match> matches;
+    const MatchStatus status = isImageWithinVideo(image, video, threshold, matches);
 
-    return results;
+    return MatchResults(status, imageMeta, videoMeta, matches);
 }
 
 // Metadata Functions
 ImageMetadata ImageSearch::getImageMetadata(const std::string& image_path)
 {
-    ImageMetadata metadata;
-    metadata.path = image_path;
+    const cv::Mat image = cv::imread(image_path);
 
-    cv::Mat image = cv::imread(image_path);
-
-    if (image.empty()) {
-        metadata.width = 0;
-        metadata.height = 0;
-        metadata.channels = 0;
-    } else {
-        metadata.width = image.cols;
-        metadata.height = image.rows;
-        metadata.channels = image.channels();
-    }
-
-    return metadata;
+    return image.empty()
+           ? ImageMetadata(image_path)
+           : ImageMetadata(image_path, image.cols, image.rows, image.channels());
 }
 
 VideoMetadata ImageSearch::getVideoMetadata(const std::string& video_path)
 {
-    VideoMetadata metadata;
-    metadata.path = video_path;
-
     cv::VideoCapture video(video_path);
 
-    if (!video.isOpened()) {
-        metadata.fps = 0.0;
-        metadata.frame_count = 0;
-        metadata.duration_sec = 0.0;
-        metadata.width = 0;
-        metadata.height = 0;
-    } else {
-        metadata.fps = video.get(cv::CAP_PROP_FPS);
-        metadata.frame_count = static_cast<int>(video.get(cv::CAP_PROP_FRAME_COUNT));
-        metadata.width = static_cast<int>(video.get(cv::CAP_PROP_FRAME_WIDTH));
-        metadata.height = static_cast<int>(video.get(cv::CAP_PROP_FRAME_HEIGHT));
+    if (video.isOpened()) {
+        const double fps = video.get(cv::CAP_PROP_FPS); 
+        const int frame_count = static_cast<int>(video.get(cv::CAP_PROP_FRAME_COUNT));
+        const double duration = fps ? frame_count / fps : 0.0;
+        const int width = static_cast<int>(video.get(cv::CAP_PROP_FRAME_WIDTH));
+        const int height = static_cast<int>(video.get(cv::CAP_PROP_FRAME_HEIGHT));
 
-        if (metadata.fps > 0) {
-            metadata.duration_sec = metadata.frame_count / metadata.fps;
-        } else {
-            metadata.duration_sec = 0.0;
-        }
+        return VideoMetadata(video_path, fps, frame_count, duration, width, height);
     }
 
-    return metadata;
+    return VideoMetadata(video_path);
 }

--- a/src/core/vfm_types.cpp
+++ b/src/core/vfm_types.cpp
@@ -34,3 +34,11 @@ ImageMetadata::ImageMetadata(const std::string& path, const int width, const int
 , height(height)
 , channels(channels)
 {}
+
+MatchResults::MatchResults(const MatchStatus status, const ImageMetadata& image,
+    const VideoMetadata& video, const std::vector<Match>& matches)
+: status(status)
+, video(video)
+, image(image)
+, matches(matches)
+{}

--- a/src/core/vfm_types.cpp
+++ b/src/core/vfm_types.cpp
@@ -1,0 +1,36 @@
+#include <vfm_types.h>
+
+Match::Match(const double time, const int index, const double score,
+    const bool has_bbox, const int x, const int y, const int w,
+    const int h)
+: time_seconds(time)
+, frame_index(index)
+, score(score)
+, has_bbox(has_bbox)
+, x(x)
+, y(y)
+, w(w)
+, h(h)
+{}
+
+VideoMetadata::VideoMetadata(const std::string& path) : VideoMetadata(path, 0.0, 0, 0.0, 0, 0) {}
+
+VideoMetadata::VideoMetadata(const std::string& path, const double fps, const int count,
+    const double dur, const int w, const int h)
+: path(path)
+, fps(fps)
+, frame_count(count)
+, duration_sec(dur)
+, width(w)
+, height(h)
+{}
+
+ImageMetadata::ImageMetadata(const std::string& path) : ImageMetadata(path, 0, 0, 0) {}
+
+ImageMetadata::ImageMetadata(const std::string& path, const int width, const int height,
+    const int channels)
+: path (path)
+, width(width)
+, height(height)
+, channels(channels)
+{}

--- a/src/core/vfm_types.h
+++ b/src/core/vfm_types.h
@@ -16,6 +16,11 @@ struct Match {
     double score;
     bool   has_bbox;
     int    x, y, w, h;
+    
+    Match() = delete;
+    Match(const double time, const int index, const double score,
+          const bool has_bbox, const int x, const int y, const int w,
+          const int h);
 };
 
 struct VideoMetadata {
@@ -25,6 +30,11 @@ struct VideoMetadata {
     double      duration_sec;
     int         width;
     int         height;
+
+    VideoMetadata() = delete;
+    VideoMetadata(const std::string& path);
+    VideoMetadata(const std::string& path, const double fps, const int count,
+                  const double dur, const int w, const int h);
 };
 
 struct ImageMetadata {
@@ -32,6 +42,11 @@ struct ImageMetadata {
     int         width;
     int         height;
     int         channels;
+    
+    ImageMetadata() = delete;
+    ImageMetadata(const std::string& path);
+    ImageMetadata(const std::string& path, const int width, const int height,
+                  const int channels);
 };
 
 struct MatchResults {

--- a/src/core/vfm_types.h
+++ b/src/core/vfm_types.h
@@ -51,9 +51,13 @@ struct ImageMetadata {
 
 struct MatchResults {
     MatchStatus              status;
-    VideoMetadata            video;
     ImageMetadata            image;
+    VideoMetadata            video;
     std::vector<Match>       matches;
+
+    MatchResults() = delete;
+    MatchResults(const MatchStatus status,const ImageMetadata& image,
+                 const VideoMetadata& video, const std::vector<Match>& matches);
 };
 
 #endif

--- a/tests/vfm_imagesearch.t.cpp
+++ b/tests/vfm_imagesearch.t.cpp
@@ -140,13 +140,13 @@ TEST(VFMImageSearch, isImageWithinVideoReturnsSuccessWhenImageFound)
     target_image.copyTo(frame_with_target(cv::Rect(0, 0, 50, 50)));
     frames.push_back(frame_with_target);
 
-    std::string video_path = createTestVideo(frames);
+    const std::string video_path = createTestVideo(frames);
     ASSERT_FALSE(video_path.empty());
 
     // When
     cv::VideoCapture video(video_path);
     std::vector<Match> matches;
-    MatchStatus result = ImageSearch::isImageWithinVideo(target_image, video, CONFIDENCE_THRESHOLD, matches);
+    const MatchStatus result = ImageSearch::isImageWithinVideo(target_image, video, CONFIDENCE_THRESHOLD, matches);
     video.release();
 
     // Then
@@ -177,13 +177,13 @@ TEST(VFMImageSearch, isImageWithinVideoReturnsNoMatchWhenImageNotFound)
     // Frame 3 Solid yellow
     frames.push_back(createTestImage(100, 100, RGB_YELLOW));
 
-    std::string video_path = createTestVideo(frames);
+    const std::string video_path = createTestVideo(frames);
     ASSERT_FALSE(video_path.empty());
 
     // When
     cv::VideoCapture video(video_path);
     std::vector<Match> matches;
-    MatchStatus result = ImageSearch::isImageWithinVideo(target_image, video, CONFIDENCE_THRESHOLD, matches);
+    const MatchStatus result = ImageSearch::isImageWithinVideo(target_image, video, CONFIDENCE_THRESHOLD, matches);
     video.release();
 
     // Then
@@ -201,7 +201,7 @@ TEST(VFMImageSearch, isImageWithinVideoReturnsBadFileForInvalidVideo)
 
     // When
     std::vector<Match> matches;
-    MatchStatus result = ImageSearch::isImageWithinVideo(target_image, video, CONFIDENCE_THRESHOLD, matches);
+    const MatchStatus result = ImageSearch::isImageWithinVideo(target_image, video, CONFIDENCE_THRESHOLD, matches);
 
     // Then
     EXPECT_EQ(MatchStatus::e_BAD_FILE, result);
@@ -224,7 +224,7 @@ TEST(VFMImageSearch, isImageWithinVideoTracksHighestConfidenceFrame)
     target_image.copyTo(frame2(cv::Rect(25, 25, 50, 50))); // Centered for potentially better match
     frames.push_back(frame2);
 
-    std::string video_path = createTestVideo(frames);
+    const std::string video_path = createTestVideo(frames);
     ASSERT_FALSE(video_path.empty());
 
     // When
@@ -273,13 +273,14 @@ TEST(VFMImageSearch, isImageWithinVideoStoresCorrectFrameCount)
     target_image.copyTo(frame_with_target(cv::Rect(10, 10, 50, 50)));
     frames.push_back(frame_with_target);
 
-    std::string video_path = createTestVideo(frames);
+    const std::string video_path = createTestVideo(frames);
     ASSERT_FALSE(video_path.empty());
 
     // When
     cv::VideoCapture video(video_path);
     std::vector<Match> matches;
-    MatchStatus result = ImageSearch::isImageWithinVideo(target_image, video, CONFIDENCE_THRESHOLD, matches);
+    const MatchStatus result =
+        ImageSearch::isImageWithinVideo(target_image, video, CONFIDENCE_THRESHOLD, matches);
     video.release();
 
     // Then
@@ -305,7 +306,7 @@ TEST(VFMImageSearch, isImageWithinVideoWithSingleFrameVideo)
     target_image.copyTo(frame(cv::Rect(0, 0, 50, 50)));
     frames.push_back(frame);
 
-    std::string video_path = createTestVideo(frames);
+    const std::string video_path = createTestVideo(frames);
     ASSERT_FALSE(video_path.empty());
 
     // When

--- a/tests/vfm_imagesearch.t.cpp
+++ b/tests/vfm_imagesearch.t.cpp
@@ -197,7 +197,7 @@ TEST(VFMImageSearch, isImageWithinVideoReturnsBadFileForInvalidVideo)
 {
     // Given
     cv::VideoCapture video("nonexistent_video.mp4");
-    cv::Mat target_image = createTestImage(50, 50);
+    const cv::Mat target_image = createTestImage(50, 50);
 
     // When
     std::vector<Match> matches;
@@ -230,7 +230,7 @@ TEST(VFMImageSearch, isImageWithinVideoTracksHighestConfidenceFrame)
     // When
     cv::VideoCapture video(video_path);
     std::vector<Match> matches;
-    MatchStatus result = ImageSearch::isImageWithinVideo(target_image, video, CONFIDENCE_THRESHOLD, matches);
+    const MatchStatus result = ImageSearch::isImageWithinVideo(target_image, video, CONFIDENCE_THRESHOLD, matches);
     video.release();
 
     // Then
@@ -288,7 +288,7 @@ TEST(VFMImageSearch, isImageWithinVideoStoresCorrectFrameCount)
     EXPECT_FALSE(matches.empty());
 
     // Find match at frame 4
-    auto frame4_match = std::find_if(matches.begin(), matches.end(),
+    const auto frame4_match = std::find_if(matches.begin(), matches.end(),
         [](const Match& m) { return m.frame_index == 4; });
     EXPECT_NE(frame4_match, matches.end());
 
@@ -312,7 +312,7 @@ TEST(VFMImageSearch, isImageWithinVideoWithSingleFrameVideo)
     // When
     cv::VideoCapture video(video_path);
     std::vector<Match> matches;
-    MatchStatus result = ImageSearch::isImageWithinVideo(target_image, video, CONFIDENCE_THRESHOLD, matches);
+    const MatchStatus result = ImageSearch::isImageWithinVideo(target_image, video, CONFIDENCE_THRESHOLD, matches);
     video.release();
 
     // Then

--- a/tests/vfm_json.t.cpp
+++ b/tests/vfm_json.t.cpp
@@ -24,20 +24,19 @@ private:
 
 TEST_F(VfmJsonTest, matchResultsToJsonCreatesValidJsonGivenSuccessfulMatchWithBbox) {
     // Given
-    MatchResults results;
-    results.status = MatchStatus::e_SUCCESS;
-    results.video = {"video.mp4", 30.0, 900, 30.0, 1920, 1080};
-    results.image = {"image.jpg", 640, 480, 3};
-
-    Match match;
-    match.time_seconds = 5.5;
-    match.frame_index = 165;
-    match.score = 0.95;
-    match.has_bbox = true;
-    match.x = 100;
-    match.y = 200;
-    match.w = 300;
-    match.h = 400;
+    MatchResults results(
+        MatchStatus::e_SUCCESS,
+        {"image.jpg", 640, 480, 3},
+        {"video.mp4", 30.0, 900, 30.0, 1920, 1080},
+        {}
+    );
+    const Match match(
+        5.5,
+        165,
+        0.95,
+        true,
+        100, 200, 300, 400
+    );
     results.matches.push_back(match);
 
     // When
@@ -68,16 +67,20 @@ TEST_F(VfmJsonTest, matchResultsToJsonCreatesValidJsonGivenSuccessfulMatchWithBb
 
 TEST_F(VfmJsonTest, matchResultsToJsonExcludesBboxGivenMatchWithoutBbox) {
     // Given
-    MatchResults results;
-    results.status = MatchStatus::e_SUCCESS;
-    results.video = {"video.mp4", 30.0, 900, 30.0, 1920, 1080};
-    results.image = {"image.jpg", 640, 480, 3};
+    MatchResults results(
+        MatchStatus::e_SUCCESS,
+        {"image.jpg", 640, 480, 3},
+        {"video.mp4", 30.0, 900, 30.0, 1920, 1080},
+        {}
+    );
 
-    Match match;
-    match.time_seconds = 12.3;
-    match.frame_index = 369;
-    match.score = 0.87;
-    match.has_bbox = false;
+    const Match match(
+        12.3,
+        369,
+        0.87,
+        false,
+        0, 0, 0, 0
+    );
     results.matches.push_back(match);
 
     // When
@@ -91,10 +94,12 @@ TEST_F(VfmJsonTest, matchResultsToJsonExcludesBboxGivenMatchWithoutBbox) {
 
 TEST_F(VfmJsonTest, matchResultsToJsonHandlesNoMatchFoundStatus) {
     // Given
-    MatchResults results;
-    results.status = MatchStatus::e_NO_MATCH_FOUND;
-    results.video = {"video.mp4", 30.0, 900, 30.0, 1920, 1080};
-    results.image = {"image.jpg", 640, 480, 3};
+    const MatchResults results(
+        MatchStatus::e_NO_MATCH_FOUND,
+        {"image.jpg", 640, 480, 3},
+        {"video.mp4", 30.0, 900, 30.0, 1920, 1080},
+        {}
+    );
 
     // When
     nlohmann::json j = vfm::matchResultsToJson(results);
@@ -106,10 +111,12 @@ TEST_F(VfmJsonTest, matchResultsToJsonHandlesNoMatchFoundStatus) {
 
 TEST_F(VfmJsonTest, matchResultsToJsonHandlesBadFileStatus) {
     // Given
-    MatchResults results;
-    results.status = MatchStatus::e_BAD_FILE;
-    results.video = {"video.mp4", 0.0, 0, 0.0, 0, 0};
-    results.image = {"image.jpg", 0, 0, 0};
+    const MatchResults results(
+        MatchStatus::e_BAD_FILE,
+        {"image.jpg"},
+        {"video.mp4"},
+        {}
+    );
 
     // When
     nlohmann::json j = vfm::matchResultsToJson(results);
@@ -120,36 +127,36 @@ TEST_F(VfmJsonTest, matchResultsToJsonHandlesBadFileStatus) {
 
 TEST_F(VfmJsonTest, matchResultsToJsonHandlesMultipleMatches) {
     // Given
-    MatchResults results;
-    results.status = MatchStatus::e_SUCCESS;
-    results.video = {"video.mp4", 30.0, 900, 30.0, 1920, 1080};
-    results.image = {"image.jpg", 640, 480, 3};
+    MatchResults results(
+        MatchStatus::e_BAD_FILE,
+        {"image.jpg", 640, 480, 3},
+        {"video.mp4", 30.0, 900, 30.0, 1920, 1080},
+        {}
+    );
 
-    Match match1;
-    match1.time_seconds = 5.5;
-    match1.frame_index = 165;
-    match1.score = 0.95;
-    match1.has_bbox = true;
-    match1.x = 100;
-    match1.y = 200;
-    match1.w = 300;
-    match1.h = 400;
+    const Match match1(
+        5.5,
+        165,
+        0.95,
+        true,
+        100, 200, 300, 400
+    );
 
-    Match match2;
-    match2.time_seconds = 12.3;
-    match2.frame_index = 369;
-    match2.score = 0.87;
-    match2.has_bbox = false;
+    const Match match2(
+        12.3,
+        369,
+        0.87,
+        false,
+        0, 0, 0, 0
+    );
 
-    Match match3;
-    match3.time_seconds = 20.1;
-    match3.frame_index = 603;
-    match3.score = 0.92;
-    match3.has_bbox = true;
-    match3.x = 50;
-    match3.y = 75;
-    match3.w = 200;
-    match3.h = 150;
+    const Match match3(
+        20.1,
+        603,
+        0.92,
+        true,
+        50, 75, 200, 150
+    );
 
     results.matches.push_back(match1);
     results.matches.push_back(match2);
@@ -170,10 +177,12 @@ TEST_F(VfmJsonTest, matchResultsToJsonHandlesMultipleMatches) {
 
 TEST_F(VfmJsonTest, matchResultsToJsonStringCreatesFormattedStringGivenIndent) {
     // Given
-    MatchResults results;
-    results.status = MatchStatus::e_SUCCESS;
-    results.video = {"video.mp4", 30.0, 900, 30.0, 1920, 1080};
-    results.image = {"image.jpg", 640, 480, 3};
+    const MatchResults results(
+        MatchStatus::e_SUCCESS,
+        {"image.jpg", 640, 480, 3},
+        {"video.mp4", 30.0, 900, 30.0, 1920, 1080},
+        {}
+    );
 
     // When
     std::string json_str = vfm::matchResultsToJsonString(results, 4);
@@ -187,11 +196,12 @@ TEST_F(VfmJsonTest, matchResultsToJsonStringCreatesFormattedStringGivenIndent) {
 
 TEST_F(VfmJsonTest, matchResultsToJsonStringCreatesCompactStringGivenNoIndent) {
     // Given
-    MatchResults results;
-    results.status = MatchStatus::e_SUCCESS;
-    results.video = {"video.mp4", 30.0, 900, 30.0, 1920, 1080};
-    results.image = {"image.jpg", 640, 480, 3};
-
+    const MatchResults results(
+        MatchStatus::e_SUCCESS,
+        {"image.jpg", 640, 480, 3},
+        {"video.mp4", 30.0, 900, 30.0, 1920, 1080},
+        {}
+    );
     // When
     std::string json_str = vfm::matchResultsToJsonString(results, -1);
 
@@ -202,27 +212,27 @@ TEST_F(VfmJsonTest, matchResultsToJsonStringCreatesCompactStringGivenNoIndent) {
 
 TEST_F(VfmJsonTest, writeMatchResultsToFileCreatesFileGivenValidPath) {
     // Given
-    MatchResults results;
-    results.status = MatchStatus::e_SUCCESS;
-    results.video = {"video.mp4", 30.0, 900, 30.0, 1920, 1080};
-    results.image = {"image.jpg", 640, 480, 3};
-
-    Match match;
-    match.time_seconds = 5.5;
-    match.frame_index = 165;
-    match.score = 0.95;
-    match.has_bbox = true;
-    match.x = 100;
-    match.y = 200;
-    match.w = 300;
-    match.h = 400;
+    MatchResults results(
+        MatchStatus::e_SUCCESS,
+        {"image.jpg", 640, 480, 3},
+        {"video.mp4", 30.0, 900, 30.0, 1920, 1080},
+        {}
+    );
+    
+    const Match match(
+        5.5,
+        165,
+        0.95,
+        true,
+        100, 200, 300, 400
+    );
     results.matches.push_back(match);
 
-    std::string filename = "test_output_valid.json";
+    const std::string filename = "test_output_valid.json";
     trackFile(filename);
 
     // When
-    bool success = vfm::writeMatchResultsToFile(results, filename, 4);
+    const bool success = vfm::writeMatchResultsToFile(results, filename, 4);
 
     // Then
     EXPECT_TRUE(success);
@@ -243,13 +253,16 @@ TEST_F(VfmJsonTest, writeMatchResultsToFileCreatesFileGivenValidPath) {
 
 TEST_F(VfmJsonTest, writeMatchResultsToFileReturnsFalseGivenInvalidPath) {
     // Given
-    MatchResults results;
-    results.status = MatchStatus::e_SUCCESS;
-    results.video = {"video.mp4", 30.0, 900, 30.0, 1920, 1080};
-    results.image = {"image.jpg", 640, 480, 3};
+    const MatchResults results(
+        MatchStatus::e_SUCCESS,
+        {"image.jpg", 640, 480, 3},
+        {"video.mp4", 30.0, 900, 30.0, 1920, 1080},
+        {}
+    );
 
     // When
-    bool success = vfm::writeMatchResultsToFile(results, "/invalid/path/that/does/not/exist/output.json", 4);
+    const bool success = vfm::writeMatchResultsToFile(
+        results, "/invalid/path/that/does/not/exist/output.json", 4);
 
     // Then
     EXPECT_FALSE(success);
@@ -257,16 +270,18 @@ TEST_F(VfmJsonTest, writeMatchResultsToFileReturnsFalseGivenInvalidPath) {
 
 TEST_F(VfmJsonTest, writeMatchResultsToFileWritesCompactJsonGivenNegativeIndent) {
     // Given
-    MatchResults results;
-    results.status = MatchStatus::e_NO_MATCH_FOUND;
-    results.video = {"video.mp4", 30.0, 900, 30.0, 1920, 1080};
-    results.image = {"image.jpg", 640, 480, 3};
+    MatchResults results(
+        MatchStatus::e_NO_MATCH_FOUND,
+        {"image.jpg", 640, 480, 3},
+        {"video.mp4", 30.0, 900, 30.0, 1920, 1080},
+        {}
+    );
 
-    std::string filename = "test_output_compact.json";
+    const std::string filename = "test_output_compact.json";
     trackFile(filename);
 
     // When
-    bool success = vfm::writeMatchResultsToFile(results, filename, -1);
+    const bool success = vfm::writeMatchResultsToFile(results, filename, -1);
 
     // Then
     EXPECT_TRUE(success);
@@ -287,21 +302,24 @@ TEST_F(VfmJsonTest, writeMatchResultsToFileOverwritesExistingFile) {
     trackFile(filename);
 
     // Create initial file
-    MatchResults results1;
-    results1.status = MatchStatus::e_NO_MATCH_FOUND;
-    results1.video = {"old_video.mp4", 25.0, 750, 30.0, 1280, 720};
-    results1.image = {"old_image.jpg", 320, 240, 3};
-
+    const MatchResults results1(
+        MatchStatus::e_NO_MATCH_FOUND,
+        {"old_image.jpg", 320, 240, 3},
+        {"old_video.mp4", 25.0, 750, 30.0, 1280, 720},
+        {}
+    );
     vfm::writeMatchResultsToFile(results1, filename, 4);
 
     // Create new results
-    MatchResults results2;
-    results2.status = MatchStatus::e_SUCCESS;
-    results2.video = {"new_video.mp4", 60.0, 1800, 30.0, 3840, 2160};
-    results2.image = {"new_image.jpg", 1920, 1080, 3};
+    const MatchResults results2(
+        MatchStatus::e_SUCCESS,
+        {"new_image.jpg", 1920, 1080, 3},
+        {"new_video.mp4", 60.0, 1800, 30.0, 3840, 2160},
+        {}
+    );
 
     // When
-    bool success = vfm::writeMatchResultsToFile(results2, filename, 4);
+    const bool success = vfm::writeMatchResultsToFile(results2, filename, 4);
 
     // Then
     EXPECT_TRUE(success);


### PR DESCRIPTION
No major issues, just structs that are not initializing default values for member primitives. Added constructors and removed default constructors that don't set values for the member data automatically. This will just add safety from undefined behavior in the event that a declared primitive is accessed. Includes `Match`, `VideoMetadata`, `ImageMetadata`, and `MatchResults`